### PR TITLE
Use exif location from photo if it exists and is far from current location

### DIFF
--- a/reusables/calculateCoordinateDistance.tsx
+++ b/reusables/calculateCoordinateDistance.tsx
@@ -1,0 +1,19 @@
+type Coordinate = {
+  lat: number;
+  lng: number;
+}
+
+export const calculateCoordinateDistance = (set1: Coordinate, set2: Coordinate) => {
+  const R = 6371e3; // metres
+  const φ1 = set1.lat * Math.PI / 180;
+  const φ2 = set2.lat * Math.PI / 180;
+  const Δφ = (set2.lat - set1.lat) * Math.PI / 180;
+  const Δλ = (set2.lng - set1.lng) * Math.PI / 180;
+
+  const a = Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) *
+    Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}

--- a/screens/SesizareNoua.tsx
+++ b/screens/SesizareNoua.tsx
@@ -21,6 +21,8 @@ import trecerePietoniVopseaStearsa from '../templates/trecerePietoniVopseaStears
 import pistaBicicleteNesigura from '../templates/pistaBicicleteNesigura';
 import pistaBicicleteInexistenta from '../templates/pistaBicicleteInexistenta';
 import masiniParcateTrecere from '../templates/masiniParcateTrecere';
+import { osmReverseLookup } from '../reusables/osmReverseLookup';
+import { calculateCoordinateDistance } from '../reusables/calculateCoordinateDistance';
 
 const templates = [
   trotuarBlocatMasini,
@@ -36,6 +38,7 @@ export default function SesizareNoua({
 }: RootTabScreenProps<'SesizareNoua'>) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [images, setImages] = useState<Array<string>>([]);
+  const [firstImageExif, setFirstImageExif] = useState<any>();
   const [isLoading, setIsLoading] = useState(false);
 
   const checkLocalStorage = async () => {
@@ -83,7 +86,27 @@ export default function SesizareNoua({
       localitate: (await AsyncStorage.getItem('localitate')) || '',
       judet: (await AsyncStorage.getItem('judet')) || '',
     };
-    const currentLocation = await getCurrentLocation();
+
+    let currentLocation = await getCurrentLocation();
+
+    // if image was taken further away from the user
+    const exif = await firstImageExif;
+    if (exif.GPSLatitude && exif.GPSLongitude && currentLocation) {
+      const distanceFromHere = calculateCoordinateDistance(
+        {lat: currentLocation?.lat, lng: currentLocation?.lng},
+        {lat: exif.GPSLatitude, lng: exif.GPSLongitude},
+      )
+
+      if(distanceFromHere > 100) {
+        Alert.alert('Poza a fost făcută departe de locația curentă. Vom folosi locația pozei în sesizare.');
+
+        currentLocation = await osmReverseLookup(
+          {lat: exif.GPSLatitude, lng: exif.GPSLongitude}
+        )
+    
+      }
+    }
+
     if (!currentLocation) {
       setIsLoading(false);
       Alert.alert(
@@ -116,9 +139,11 @@ export default function SesizareNoua({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,
       quality: 0,
+      exif: true,
     });
 
     if (!result.cancelled && result.uri) {
+      setFirstImageExif(result.exif);
       setImages([...images, result.uri]);
     }
   };


### PR DESCRIPTION
Înainte de trimiterea email-ului se verifică dacă prima poză a fost făcută la mai mult de 100 de metri de locația curentă. Dacă da, atunci aplicația va folosi locația pozei în locul locației curente în sesizare.

Din pacate nu am reusit sa implementez un exif scrambler asa repede, poate vine intr-un alt PR.

![IMG_4637](https://user-images.githubusercontent.com/17914968/166024159-f0c5526b-5dab-451d-8202-540a7c000cbd.jpg)

